### PR TITLE
Added a test that checks if dnssec_status equals getdns.DNSSEC_SECURE for a known domain and upstream server

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -169,7 +169,7 @@ describe("getdns test", function() {
         });
     });
 
-    describe("DNSSEC options", function() {
+    describe("DNSSEC", function() {
         it("should return with dnssec_status", function(done) {
             var ctx = getdns.createContext({
                 "stub" : true,
@@ -185,16 +185,11 @@ describe("getdns test", function() {
                 finish(ctx, done);
             });
         });
-    });
 
-    describe("DNSSEC options", function() {
-        it("should return with dnssec_status getdns.DNSSEC_SECURE", function(done) {
+        it("should return with dnssec_status getdns.DNSSEC_SECURE when not in stub mode", function(done) {
             var ctx = getdns.createContext({
                 "stub" : false,
-                "return_dnssec_status" : true,
-                "upstreams" : [
-                    "8.8.8.8"
-                ]
+                "return_dnssec_status" : true
             });
             ctx.getAddress("getdnsapi.net", function(err, result) {
                 expect(err).to.not.be.ok();


### PR DESCRIPTION
While I have only run this in my own development environment, which I can't be sure is 100% correctly set up, I hope it's a reasonable and repeatable test.
