### PR TITLE
convertBinData: provide size to avoid overrun

### DIFF
--- a/src/GNUtil.cpp
+++ b/src/GNUtil.cpp
@@ -269,7 +269,7 @@ static Handle<Value> convertBinData(getdns_bindata* data,
     }
     // basic string?
     if (printable) {
-        return NanNew<String>((char*) data->data);
+        return NanNew<String>( (char*) data->data, data->size );
     // the root
     } else if (data->size == 1 && data->data[0] == 0) {
         return NanNew<String>(".");


### PR DESCRIPTION
When convertBinData detects printable text, it converts it to a string type.  The size of this string should come from the size in the bindata structure, to avoid reading beyond the end of the buffer.

... testing ...

To prove to myself that this is a valid fix (it's hard to reproduce otherwise because it depends on contents of memory), I hacked up a modified version of getdns, which allocates guard data beyond the end of the bindata buffer.  Without the fix, whatever is in memory beyond the string gets included in the output, with the fix it terminates at the correct point.

-------------------------------- src/context.c --------------------------------
index 45e4b47..4b0ca63 100644
@@ -1971,12 +1971,16 @@ getdns_bindata_copy(struct mem_funcs *mfs,

 	dst->size = src->size;
 	if ((dst->size = src->size)) {
-		dst->data = GETDNS_XMALLOC(*mfs, uint8_t, src->size);
+		dst->data = GETDNS_XMALLOC(*mfs, uint8_t, src->size + 4);
 		if (!dst->data) {
 			GETDNS_FREE(*mfs, dst);
 			return NULL;
 		}
 		(void) memcpy(dst->data, src->data, src->size);
+		dst->data[src->size] = 'W';
+		dst->data[src->size+1] = 'T';
+		dst->data[src->size+2] = 'F';
+		dst->data[src->size+3] = '!';
 	} else {
 		dst->data = nodata;
 	}