### PR TITLE
Attempt to fix travis builds on iojs/node v4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: node_js
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+env:
+  - CXX=g++-4.8
 before_install:
   - sudo apt-get update
   - sudo apt-get install libunbound-dev libldns-dev libidn11-dev check libevent-dev unbound-anchor


### PR DESCRIPTION
- For builds on iojs as well as node v4+ a newer compiler is needed.
- [Using gcc/g++ 4.8 should fix the issue.](https://github.com/travis-ci/travis-ci/issues/4771)