### PR TITLE
Use openssl-1.0.2h for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,30 @@ env:
   - CXX=g++-4.8
 before_install:
   - sudo apt-get update
-  - sudo apt-get install libunbound-dev libldns-dev libidn11-dev check libevent-dev unbound-anchor
-  - curl -O http://getdnsapi.net/dist/getdns-1.0.0b1.tar.gz
+  - sudo apt-get install libldns-dev libidn11-dev check libevent-dev unbound-anchor
+  - mkdir -p openssl
+  - export OPENSSL_PREFIX="$PWD/openssl"
+  - curl -O https://www.openssl.org/source/openssl-1.0.2h.tar.gz
+  - tar -xf openssl-1.0.2h.tar.gz
+  - cd openssl-1.0.2h
+  - ./config --prefix="$OPENSSL_PREFIX" --openssldir="${OPENSSL_PREFIX}/etc/ssl" --libdir=lib shared zlib-dynamic
+  - make depend
+  - make
+  - make install
+  - cd ..
+  - mkdir -p unbound
+  - export UNBOUND_PREFIX="$PWD/unbound"
+  - curl -O https://www.unbound.net/downloads/unbound-1.5.9.tar.gz
+  - tar -xf unbound-1.5.9.tar.gz
+  - cd unbound-1.5.9
+  - ./configure --prefix="$UNBOUND_PREFIX" --with-ssl="$OPENSSL_PREFIX"
+  - make
+  - make install
+  - cd ..
+  - curl -O https://getdnsapi.net/dist/getdns-1.0.0b1.tar.gz
   - tar -xf getdns-1.0.0b1.tar.gz
   - cd getdns-1.0.0b1
-  - ./configure
+  - ./configure --with-ssl="$OPENSSL_PREFIX" --with-libunbound="$UNBOUND_PREFIX"
   - make
   - sudo make install
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,7 @@ node_js:
   - "5"
   - "6"
   - "node"
+matrix:
+  allow_failures:
+  - node_js: "0.10"
+  - node_js: "0.12"

--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "nan": "^2.4.0"
   },
   "devDependencies": {
-    "mocha": "^2.2.5",
+    "async": "^1.2.0",
     "expect.js": "^0.3.1",
-    "async": "^1.2.0"
+    "mocha": "^2.2.5",
+    "segfault-handler": "^1.0.0"
   },
   "engines": {
-      "node": "^0.12.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-      "npm": "^2.0.0 || ^3.0.0"
+    "node": "^0.12.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+    "npm": "^2.0.0 || ^3.0.0"
   },
   "scripts": {
     "postinstall": "node-gyp clean rebuild",

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,12 @@ describe("getdns test", function() {
     // requires
     var expect = require('expect.js'),
         getdns = require("../getdns"),
-        async  = require("async");
+        async  = require("async"),
+        segfaultHandler = require("segfault-handler"),
+        segfaultDumpFilename = "crash.log";
+
+    // Dump segfault stacktraces both to the console and to a file.
+    segfaultHandler.registerHandler(segfaultDumpFilename);
 
     // Basic creation w/ various opts
     describe("Context Create", function() {
@@ -249,7 +254,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
         });
 
         it("should return with dnssec_status getdns.DNSSEC_SECURE when not in stub mode", function(done) {
@@ -287,7 +292,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
       });
     });
 
@@ -343,7 +348,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
         });
         it("TLS tls fallback tcp should return successfully", function(done) {
             this.timeout(10000);
@@ -360,7 +365,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
         });
         it("TLS starttls first should return successfully", function(done) {
             this.timeout(10000);
@@ -378,7 +383,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
         });
     });
 
@@ -408,7 +413,7 @@ describe("getdns test", function() {
                 expect(result.replies_tree).to.be.an(Array);
                 expect(result.replies_tree).to.not.be.empty();
                 finish(ctx, done);
-            }); 
+            });
         });
     });
 
@@ -432,7 +437,7 @@ describe("getdns test", function() {
             });
       });
     });
-    
+
     describe("SUFFIX", function() {
         it("SUFFIX should return successfully", function(done) {
             this.timeout(10000);
@@ -478,7 +483,7 @@ describe("getdns test", function() {
             });
       });
     });
-    
+
     describe("APPENDNAME", function() {
         it("APPENDNAME should return successfully", function(done) {
             this.timeout(10000);
@@ -489,7 +494,7 @@ describe("getdns test", function() {
                     "8.8.8.8"
                 ]
             });
-            ctx.suffix = "org";           
+            ctx.suffix = "org";
 	    ctx.append_name = getdns.APPEND_NAME_ALWAYS; //APPEND_NAME_TO_SINGLE_LABEL_FIRST;
             ctx.general("www.verisignlabs", getdns.RRTYPE_A, {"return_call_reporting" : true}, function(err, result) {
 //                console.log(JSON.stringify(result, null, 2));
@@ -502,4 +507,3 @@ describe("getdns test", function() {
       });
     });
 });
-


### PR DESCRIPTION
- Getdns (currently 1.0.0b1) checks for OpenSSL/libssl TLS hostname authentication support (`SSL_CTX_get0_param`) and sets a flag (`HAVE_SSL_HN_AUTH`) if it's supported.
- Support and [the flag `SSL_CTX_get0_param` was introduced in OpenSSL 1.0.2](https://www.openssl.org/docs/manmaster/ssl/SSL_get0_param.html).
- The [Travis tests run on Ubuntu "Precise"](https://docs.travis-ci.com/user/ci-environment/), which [has OpenSSL 1.0.1 as a package](http://packages.ubuntu.com/precise/openssl) at the moment.
- Without support the getdns-node TLS hostname tests will always fail.
- In order to pass the tests, OpenSSL 1.0.2 needs to be downloaded and installed during Travis builds.