### PR TITLE
Target getdns 1.0.0b2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
   - make
   - make install
   - cd ..
-  - curl -O https://getdnsapi.net/dist/getdns-1.0.0b1.tar.gz
-  - tar -xf getdns-1.0.0b1.tar.gz
-  - cd getdns-1.0.0b1
+  - curl -O https://getdnsapi.net/dist/getdns-1.0.0b2.tar.gz
+  - tar -xf getdns-1.0.0b2.tar.gz
+  - cd getdns-1.0.0b2
   - ./configure --with-ssl="$OPENSSL_PREFIX" --with-libunbound="$UNBOUND_PREFIX"
   - make
   - sudo make install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "getdns",
-  "version": "1.0.0b1",
-  "description": "getdns bindings for Node.js.  Requires getdns 1.0.0b1 or above.",
+  "version": "1.0.0b2",
+  "description": "getdns bindings for Node.js. Requires getdns 1.0.0b2 or above.",
   "main": "getdns.js",
   "keywords": [
     "dns",


### PR DESCRIPTION
- Upgrades the getdns dependency to [getdns 1.0.0b2](https://github.com/getdnsapi/getdns/tree/v1.0.0b2).
- The semantic versioning standard should be used in future releases. Will open a new issue for this.