### PR TITLE
Support renamed GETDNS_RCODE_BADCOOKIE

### DIFF
--- a/src/GNConstants.cpp
+++ b/src/GNConstants.cpp
@@ -236,5 +236,19 @@ void GNConstants::Init(Local<Object> target) {
     SetConstant("RCODE_BADNAME",GETDNS_RCODE_BADNAME,exports);
     SetConstant("RCODE_BADALG",GETDNS_RCODE_BADALG,exports);
     SetConstant("RCODE_BADTRUNC",GETDNS_RCODE_BADTRUNC,exports);
+
+// NOTE: workaround for breaking change in upstream getdns versions after getdns v1.6.0; GETDNS_RCODE_COOKIE constant was renamed to GETDNS_RCODE_BADCOOKIE.
+// NOTE: the renamed constant has not yet been included in an upstream getdns released, so this is a preemptive measure.
+// https://github.com/getdnsapi/getdns-node/issues/38
+// https://github.com/getdnsapi/getdns/pull/471
+// https://github.com/getdnsapi/getdns/commit/5c79e2c7315f0aa235bb0b2adf26ce2129786e7f
+#ifdef GETDNS_RCODE_BADCOOKIE
+    SetConstant("RCODE_BADCOOKIE",GETDNS_RCODE_BADCOOKIE,exports);
+#else
+    // TODO: remove deprected legacy COOKIE constant support a few major getdns-node releases after BADCOOKIE has been made released in the upstream getdns.
     SetConstant("RCODE_COOKIE",GETDNS_RCODE_COOKIE,exports);
+
+    // NOTE: transitioning the constant; use BADCOOKIE instead of COOKIE (deprecated).
+    SetConstant("RCODE_BADCOOKIE",GETDNS_RCODE_COOKIE,exports);
+#endif
 }


### PR DESCRIPTION
- Workaround for breaking change in upstream getdns versions after `getdns` v1.6.0; `GETDNS_RCODE_COOKIE` constant was renamed to `GETDNS_RCODE_BADCOOKIE`.
- The renamed constant has not yet been included in an upstream `getdns` released, so this is a preemptive measure.

Fixes #38.

See

- https://github.com/getdnsapi/getdns-node/issues/38
- https://github.com/getdnsapi/getdns
- https://github.com/getdnsapi/getdns/pull/471
- https://github.com/getdnsapi/getdns/commit/5c79e2c7315f0aa235bb0b2adf26ce2129786e7f

---

To test using latest `getdns` on Ubuntu 21.04.

```shell
sudo apt install libunbound-dev libidn2-dev libssl-dev libevent-dev libuv1-dev libev-dev check

git clone 'git@github.com:getdnsapi/getdns.git'

cd getdns

mkdir build

cd build

cmake ..

make
```

Rebuild `getdns-node` targeting the newly built version (without installing it).

```shell
LIBRARY_PATH="/the/path/to/your/getdns/build" CPLUS_INCLUDE_PATH="/the/path/to/your/getdns/build" npm run --silent rebuild
```

Current `getdns` commit on the `develop` branch is `291e0018817269b72c7cbd6c3e531acba95f563f`.

- https://github.com/getdnsapi/getdns/tree/develop
- https://github.com/getdnsapi/getdns/commit/291e0018817269b72c7cbd6c3e531acba95f563f